### PR TITLE
fix: CourseWidget 카드 크기 고정

### DIFF
--- a/components/Instructor/Dashboard-Section/widgets/CourseWidget.js
+++ b/components/Instructor/Dashboard-Section/widgets/CourseWidget.js
@@ -153,7 +153,7 @@ const CourseWidget = ({
 
   return (
     <>
-      <div className="rbt-card variation-01 rbt-hover">
+      <div className="rbt-card variation-05 rbt-hover">
         <div className="rbt-card-img">
           <Link href={`/course-details/${data.id}`}>
             <Image

--- a/public/scss/elements/_card.scss
+++ b/public/scss/elements/_card.scss
@@ -544,6 +544,66 @@
         }
     }
 
+    &.variation-05 {
+        // CourseWidget 전용 - 크기 완전 고정
+        min-height: 420px;
+        max-height: 420px;
+        display: flex;
+        flex-direction: column;
+        
+        .rbt-card-img {
+            flex-shrink: 0;
+            
+            a {
+                display: block;
+                aspect-ratio: 330 / 227;
+                overflow: hidden;
+                
+                img {
+                    width: 100%;
+                    height: 100%;
+                    object-fit: cover;
+                    border-radius: var(--radius);
+                }
+            }
+        }
+        
+        .rbt-card-body {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+            
+            .rbt-card-top {
+                flex-shrink: 0;
+            }
+            
+            .rbt-card-title {
+                overflow: hidden;
+                text-overflow: ellipsis;
+                display: -webkit-box;
+                -webkit-line-clamp: 2;
+                -webkit-box-orient: vertical;
+                min-height: 3em;
+                line-height: 1.5em;
+                max-height: 3em;
+            }
+            
+            .rbt-meta {
+                flex-shrink: 0;
+            }
+            
+            .rbt-author-meta {
+                flex-shrink: 0;
+            }
+            
+            .rbt-card-bottom {
+                margin-top: auto;
+                flex-shrink: 0;
+            }
+        }
+    }
+
     &.height-330 {
         .rbt-card-img {
             a {


### PR DESCRIPTION
## Summary
- CourseWidget 전용 variation-05 클래스 생성
- 카드 크기 완전 고정 (420px)
- 다른 컴포넌트에 영향 없음

## Changes
- `_card.scss`: variation-05 스타일 추가
  - 카드 높이 420px로 고정
  - 이미지 비율 330:227로 고정
  - 제목 2줄까지만 표시, ellipsis 적용
- `CourseWidget.js`: variation-01 → variation-05 변경

## Test
- ✅ instructor-personal-courses 페이지에서 Draft/Pending/Published 카드 크기 동일
- ✅ 콘텐츠 길이와 무관하게 카드 크기 유지
- ✅ 다른 페이지의 variation-01 카드들은 영향받지 않음

Closes #24

🤖 Generated with [Claude Code](https://claude.ai/code)